### PR TITLE
Bug/fix psycopg conn

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,2 +1,4 @@
 Version 1.5.31
 New AWS ecs handler. Now allow to increase ASG waiting for the instance before place the deiserd task.
+Version 1.5.34
+Fix psycopg connection pool. psycopg2.pool.SimpleConnectionPool does not automatically check if a connection retrieved from the pool is closed or stale. If a connection is closed (e.g., due to being idle for too long, network issues, or being explicitly closed), the pool will still return it as if it were valid.

--- a/tmgr/__init__.py
+++ b/tmgr/__init__.py
@@ -2,7 +2,7 @@
    tmgr module 
 """
 __name__ = 'simple_task_manager'
-__version__     = '1.5.33'
+__version__     = '1.5.34'
 __author__      = 'Francisco R. Moreno Santana'
 __contact__     = 'franrms@gmail.com'
 __homepage__    = 'https://github.com/Fran-4c4/staskmgr'


### PR DESCRIPTION
Fix psycopg connection pool. psycopg2.pool.SimpleConnectionPool does not automatically check if a connection retrieved from the pool is closed or stale. If a connection is closed (e.g., due to being idle for too long, network issues, or being explicitly closed), the pool will still return it as if it were valid.